### PR TITLE
[WIP] Add mac system to build target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     rust-overlay,
     ...
   }: let
-    systems = ["x86_64-linux" "aarch64-darwin" "x86_64-darwin"];
+    systems = ["x86_64-linux" "aarch64-darwin"];
     forAllSystems = f:
       nixpkgs.lib.genAttrs systems
       (system:
@@ -40,7 +40,6 @@
         buildInputs =
           (nixpkgs.lib.optionals pkgs.stdenv.isLinux [pkgs.alsa-lib])
           ++ (nixpkgs.lib.optionals pkgs.stdenv.isDarwin [
-            pkgs.darwin.apple_sdk.frameworks.CoreAudio
             pkgs.darwin.apple_sdk.frameworks.CoreMIDI
           ]);
       });


### PR DESCRIPTION
Please assist @carlhammann: buildInputs are most likely breaking on Linux now, since I'm not sure about how to work with the lib.optionals and isLinux flag. This has to be merged in the code somehow.