### PR TITLE
Improve line spacing of the lattice

### DIFF
--- a/src/gui/lattice.rs
+++ b/src/gui/lattice.rs
@@ -230,20 +230,18 @@ fn activation_color<T: StackType>(
 }
 
 fn text_rect<T: StackType>(ui: &egui::Ui, text: &str, controls: &LatticeWindowControls<T>) -> Rect {
-    // Zugriff auf die Schriftmetriken
     let fonts = ui.fonts(|f| f.clone());
 
-    // Layout erstellen – kein Zeilenumbruch
+    // Create galley layout for measuring dimensions
     let galley = fonts.layout_no_wrap(
         text.to_owned(),
         egui::FontId::proportional(controls.zoom * FONT_SIZE),
         egui::Color32::WHITE,
     );
 
-    // Galley enthält bereits die Größe
     let size: Vec2 = galley.size();
 
-    // Wir erzeugen ein Rect von (0,0) bis (width,height)
+    // Create the rect surrounding the text 
     Rect::from_min_size(egui::Pos2::ZERO, size)
 }
 


### PR DESCRIPTION
This adds a calculation function which uses a not-rendered Galley to determine the dimensions of a given text string.
Also it uses it to paint a rect as a spacing between text and lattice lines.