### PR TITLE
Make the retemper popup appear again

### DIFF
--- a/src/gui/lattice.rs
+++ b/src/gui/lattice.rs
@@ -332,7 +332,6 @@ impl<T: StackType + HasNoteNames> OneNodeDrawState<T> {
             for b in self.tmp_temperaments.iter_mut() {
                 *b = false;
             }
-            Popup::toggle_id(ui.ctx(), popup_id);
             self.tmp_relative_stack.clone_from(stack);
             self.tmp_relative_stack.scaled_add(-1, reference);
 


### PR DESCRIPTION
In #14, we updated our egui dependency. Yesterday we realised this broke the popup used to apply temperaments or commas to individual notes. This is because the new popup API is nicer, in that we don't need to manually toggle popups any more: The line I deleted toggles used to toggle it on, but with the new API, it immediately closed the popup.

This is only a PR so that @christianbratschke13 sees that the problem is mended :slightly_smiling_face: 